### PR TITLE
[FEATURE]: fix design token

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -11,7 +11,7 @@ const theme = createTheme({
       main: DESIGN_TOKEN.color.primary[3],
     },
     secondary: {
-      main: DESIGN_TOKEN.color.secondary[2],
+      main: DESIGN_TOKEN.color.secondary[4],
     },
     text: {
       primary: DESIGN_TOKEN.color.primary[1],


### PR DESCRIPTION
I think the default secondary color should be secondary 4 (#E8360E) because Figma is usually used color #E8360E in every topic
![image](https://github.com/asc-base/acs-web-ui/assets/112146897/d550495e-40c8-400f-a821-2db1c71881ed)
